### PR TITLE
Adjusted to allow for push of tag on bump-only command

### DIFF
--- a/tasks/bump.js
+++ b/tasks/bump.js
@@ -44,7 +44,6 @@ module.exports = function(grunt) {
       grunt.verbose.writeln('Only incrementing the version.');
 
       opts.commit = false;
-      opts.createTag = false;
       opts.push = false;
     }
 
@@ -197,7 +196,18 @@ module.exports = function(grunt) {
           grunt.fatal('Can not create the tag:\n  ' + stderr);
         }
         grunt.log.ok('Tagged as "' + tagName + '"');
-        next();
+        if ( incOrCommitOnly === 'bump-only' ){  // push tag only
+          exec('git push ' + opts.pushTo + ' ' + tagName, function(err,stdout,stderr){
+            if (err) {
+              grunt.fatal('Can not push the tag:\n  ' + stderr);
+            }else{ 
+              grunt.log.ok('Tag ' + tagName + ' successfully pushed to ' + opts.pushTo);
+            }
+            next();
+          })
+        }else{ 
+          next();
+        }
       });
     });
 
@@ -226,3 +236,4 @@ module.exports = function(grunt) {
   DESC = 'Commit, tag, push without incrementing the version.';
   grunt.registerTask('bump-commit', DESC, 'bump::commit-only');
 };
+


### PR DESCRIPTION
have use case: 

1. bump locally with provided version # (supplied by CI system)
2. push version tag to master 

there's no need to push config.xml to master since our version # is managed externally to source control.  Pushing updated config.xml files only adds cluttered commits in revision history.